### PR TITLE
Enhanced functionality 

### DIFF
--- a/code/README
+++ b/code/README
@@ -29,6 +29,8 @@ using 'touch' or it's equivalent.
 
 Usage:
 python3 getReport.py -f <filter id>
+		     -t Task name
+		     -P produce PDF of report
                      -d disable details
 	             -p enable pagination
 	             -s custom filter string
@@ -38,10 +40,16 @@ python3 getReport.py -f <filter id>
         in GVM. If this filter id doesn't exist the no results will be returned and
 	the getReport process will die
 
+    -t: this is the task name associated with the scans. Not entering the task name
+    	will process all reports matching the filter id. This is useful if you have
+	one scanner for several networks or network segments
+
+    -P: create a PDF (generic version) of the report using the requested filter id. 
+
     -d: disable details in the report. Off by default
 
     -p: enable pagination. Return the results as pages. This is of limited value
-        and will return truncate results.
+        and will return truncated results.
 
     -s: pass a custom filter string to GVM. Invalid filter strings may produce results
         but the value of those results may be limited. When using a custom filter string

--- a/code/README
+++ b/code/README
@@ -1,0 +1,90 @@
+Introduction: 
+Ibex is a utility to export reports from a Greenbone server and export them into both
+CSV and JSON format. The JSON format is appropriate for input in to LogStash,
+ElasticSearch, and the like.
+
+Ibex is based on Openvas-Exporter written by Mattias Hemmingsson
+(https://github.com/mattiashem/openvas-exporter/)
+
+Why Ibex? I was typing 'ovex' as shorthand for openvas-exporter and typoed it as
+ibex. Seemed like a good name to use and ibexes are pretty darn cool.
+
+Dependencies:
+Ibex depends on the following python3 modules
+gvm-tools, untangle, and python-gvm
+
+Configuration:
+Ibex is configured via the config.ini file found in the config directory. This
+file must exist for getReport to run. The contents of the config.ini file are:
+
+[DEFAULT]
+username=[username for GVM]
+password=[user password for GVM]
+host=[GVM host]
+datafolder=[root diretcory to store results]
+reportfile=[path to file for previousy generate results]
+
+NOTE: the reportfile *must* exist. So before your first run create the file
+using 'touch' or it's equivalent. 
+
+Usage:
+python3 getReport.py -f <filter id>
+                     -d disable details
+	             -p enable pagination
+	             -s custom filter string
+	             -o overwrite previously processed reports
+
+    -f: the filter id is the UUID string that correspond to a pre-existing filter
+        in GVM. If this filter id doesn't exist the no results will be returned and
+	the getReport process will die
+
+    -d: disable details in the report. Off by default
+
+    -p: enable pagination. Return the results as pages. This is of limited value
+        and will return truncate results.
+
+    -s: pass a custom filter string to GVM. Invalid filter strings may produce results
+        but the value of those results may be limited. When using a custom filter string
+	the text of the string is hashed and used to create a diretcory in the data directory.
+	Results will be stored here along with a file containing the filter string called
+	'filter_string.txt'
+
+    -o: Overwrite previous generated results. Ibex stores the report ID and filter ID
+        to create a unique key. This key is used to skip over results that have already
+	been generated. Using this option will regenerate those results.
+
+Example run:
+python3 newReport.py -s "min_qod=70 autofp=0 apply_overrides=1 notes=1 overrides=1 result_hosts_only=1 first=1 rows=100 sort-reverse=severity levels=hml"
+Details enabled
+Ignore pagination enabled
+Running reports with no filter id
+Running custom report with filter:  min_qod=70 autofp=0 apply_overrides=1 notes=1 overrides=1 result_hosts_only=1 first=1 rows=100 sort-reverse=severity levels=hml
+Loading previously completed reports data
+Starting report processing
+Connected to: gvm.example.com
+Getting reports
+Retreived reports
+Fetched the following scans from gvm.example.com
+{'content_type': 'text/xml', 'id': '32b3c666-24aa-4927-a2dc-bd40c5319a6d', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': '87e99618-2ca6-41fa-bb9d-5121f0fc8c9d', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': 'db9a7c67-7499-4e13-8c80-628cf84e91f6', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': 'ae075408-c4fc-4aba-b65e-41ced302fde1', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': '9673ef0a-b0df-4cd0-b090-5dc6b9baaff3', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': '1d832542-c4c8-492e-8f93-990f28441485', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+{'content_type': 'text/xml', 'id': '8e67eb42-a2c6-942a-23af-102bc45a7832', 'format_id': 'a994b278-1f62-11e1-96ac-406186ea4fc5', 'type': 'scan', 'extension': 'xml'}
+Processing Report ID: 32b3c666-24aa-4927-a2dc-bd40c5319a6d
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: 87e99618-2ca6-41fa-bb9d-5121f0fc8c9d
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: db9a7c67-7499-4e13-8c80-628cf84e91f6
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: ae075408-c4fc-4aba-b65e-41ced302fde1
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: 9673ef0a-b0df-4cd0-b090-5dc6b9baaff3
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: 1d832542-c4c8-492e-8f93-990f28441485
+This report was processed on 2020-07-23 14:02:38.905777
+Processing Report ID: 8e67eb42-a2c6-942a-23af-102bc45a7832
+Writing CSV file:  data/369fd4828387ae3438b29bd6afc498e1f028f760/8e67eb42-a2c6-942a-23af-102bc45a7832.csv
+Writing JSON file:  data/369fd4828387ae3438b29bd6afc498e1f028f760/8e67eb42-a2c6-942a-23af-102bc45a7832.json
+

--- a/code/config/config.base
+++ b/code/config/config.base
@@ -1,0 +1,8 @@
+[DEFAULT]
+username=pscnoc
+password=3529aabd-65b9-4303-9135-268a9c204c96
+host=baba-admin.psc.edu
+port=22
+basepath=/opt/openvas-exporter/code
+datafolder=data
+reportfile=completedReports.txt

--- a/code/config/config.ini
+++ b/code/config/config.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 username=admin
-password=admin
-host=gvmd
+password=3529aabd-65b9-4303-9135-268a9c204c96
+host=baba.psc.edu
 datafolder=data
+reportfile=/opt/openvas-exporter/code/completedReports.txt

--- a/code/config/config.ini
+++ b/code/config/config.ini
@@ -1,7 +1,0 @@
-[DEFAULT]
-username=admin
-password=96a3709f-54d2-46ba-b64e-12684e305e77
-host=shaun.psc.edu
-port=9390
-datafolder=data-shaun
-reportfile=/opt/openvas-exporter/code/data-shaun/completedReports.txt

--- a/code/config/config.ini
+++ b/code/config/config.ini
@@ -1,6 +1,7 @@
 [DEFAULT]
 username=admin
-password=3529aabd-65b9-4303-9135-268a9c204c96
-host=baba.psc.edu
-datafolder=data
-reportfile=/opt/openvas-exporter/code/completedReports.txt
+password=96a3709f-54d2-46ba-b64e-12684e305e77
+host=shaun.psc.edu
+port=9390
+datafolder=data-shaun
+reportfile=/opt/openvas-exporter/code/data-shaun/completedReports.txt

--- a/code/config/config.tmp
+++ b/code/config/config.tmp
@@ -1,5 +1,0 @@
-[DEFAULT]
-username=$USERNAME
-password=$PASSWORD
-host=$GSAD_HOST
-datafolder=$DATA

--- a/code/config/ibex.config
+++ b/code/config/ibex.config
@@ -1,0 +1,3 @@
+config: base
+client: e0215f70-0050-43f6-bbcf-ad18c6abae0e
+raw: 4fab5aac-1190-4c7b-a2d9-e2a87ecc4887

--- a/code/getReport.py
+++ b/code/getReport.py
@@ -68,9 +68,9 @@ def exportReports(filterID, filterString, optPagination, optDetails, optRewrite)
 
     #connect to our host as defined in the config file
     print ("Trying to connect to: '", config['DEFAULT']['host'], "' on port: '", config['DEFAULT']['port'],"'")
-    connection = TLSConnection(hostname=config['DEFAULT']['host'],timeout=300)
+    connection = TLSConnection(hostname=config['DEFAULT']['host'],timeout=3600)
     if config['DEFAULT']['port']: 
-        connection = TLSConnection(hostname=config['DEFAULT']['host'],port=config['DEFAULT']['port'],timeout=300)
+        connection = TLSConnection(hostname=config['DEFAULT']['host'],port=config['DEFAULT']['port'],timeout=3600)
     print('Starting report processing')
     
     with Gmp(connection) as gmp:
@@ -91,7 +91,7 @@ def exportReports(filterID, filterString, optPagination, optDetails, optRewrite)
 
         getReports=[] #array of reportIDs
         print ('Getting reports')
-        allreports = gmp.get_reports(no_details=True) #we only need the reportID so minimize the data returned
+        allreports = gmp.get_reports(details=0) #we only need the reportID so minimize the data returned
         print ('Retreived reports')
         allreports_root = ET.fromstring(allreports)
         print("Fetched the following scans from %s" %(config['DEFAULT']['host']))

--- a/code/getReport.py
+++ b/code/getReport.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from gvm.connections import TLSConnection
 from gvm.protocols.gmp import Gmp
 from gvm.transforms import EtreeTransform
@@ -6,32 +7,62 @@ import xml.etree.ElementTree as ET
 import untangle
 import base64
 import csv, json
-import os.path
+import os
 from os import path
+from os import makedirs
 import configparser
+import sys
+import getopt
+import hashlib
 
 # Read the configfile
 config = configparser.ConfigParser()
 config.sections()
 config.read('config/config.ini')
 
+#get the current datetime once
+current_datetime = datetime.now()
 
-
-connection = TLSConnection(hostname=config['DEFAULT']['host'])
-
-
-
-def exportReports():
+'''
+This function reads in the list of already processed reports and stores it as an array
+ranReports[reportID][filterID][date]
+The date is just so people know when that report was first generated 
+The data format of the incoming file is reportID, filterID, date
+All values are in ASCII.
+'''
+def readRanReportsFile():
+    ranReports = {}
+    reportFile = open(config['DEFAULT']['reportfile'],'r')
+    reportData = reportFile.readlines();
+    reportFile.close();
+    i = 0
+    for data in reportData:
+        values = data.split(",", 2) #split at the comma, only return 1st 3 items
+        # unnecessary use of variables here but it makes it easier to understand
+        filterID = values[0].strip();
+        reportID = values[1].strip();
+        datetime = values[2].strip();
+        key = filterID + reportID #this should be unique to every report and filter
+        ranReports.update({key: datetime})
+    return ranReports
+#end readRanReportsFile
+    
+def exportReports(filterID, filterString, optPagination, optDetails, optRewrite):
     '''
-     This will add a target to the list and start the sca of the targets
+     This will add a target to the list and start the scan of the targets
     '''
 
+    print('Loading previously completed reports data');
+    ranReports = readRanReportsFile();
 
+    connection = TLSConnection(hostname=config['DEFAULT']['host'],timeout=300)
+    print('Starting report processing')
+    
     with Gmp(connection) as gmp:
         # Login
         gmp.authenticate(config['DEFAULT']['username'], config['DEFAULT']['password'])
+        print('Connected to:', config['DEFAULT']['host'])
         
-
         #Get the CSV report type
         reportFormatID=""
         report_format = gmp.get_report_formats()
@@ -41,12 +72,13 @@ def exportReports():
             for report_format in report:
                 if report_format.text == 'CSV result list.':
                     reportFormatID= report.attrib.get('id')
-                    #reportFromatData = gmp.get_report_format(reportFormatID)
-                    #pretty_print(reportFromatData)
 
         getReports=[]
+        print ('Getting reports')
         allreports = gmp.get_reports()
+        print ('Retreived reports')
         allreports_root = ET.fromstring(allreports)
+        print("Fetched the following scans from %s" %(config['DEFAULT']['host']))
         for report in allreports_root:
             if report.tag == 'report':
                 for onereport in report:
@@ -58,60 +90,160 @@ def exportReports():
 
         #Get out the reports and get them as csv files to use
         for reportID in getReports:
-            print("################{0}".format(reportID))
-            reportscv = gmp.get_report(reportID,report_format_id=reportFormatID,filter="apply_overrides=0 min_qod=70",ignore_pagination=True,details=True)
-            #pretty_print(reportscv)
+            print("Processing Report ID: {0}".format(reportID))
+
+            # we have a reportID. Check to see if it matches any existing reports already written to disk
+            # if it does then we can skip this one. Note: we make sure filterID is null because we
+            # only need to do the hashing once. 
+            if filterString and not filterID:
+                # we need a consistent identify for this string so hashes to the rescue
+                # we are going to reuse the filterID variable to hold it
+                sha_1 = hashlib.sha1() #instantiate hash
+                sha_1.update(filterString.encode('utf-8')) #hash the string being sure to use proper encoding
+                filterID = sha_1.hexdigest() #return the hash as a hex string                
+
+            # we use the filterID and the rpeortID to create a key for the ranReports dict. If it exists then skip
+            # that report unless we are over writing (or regenerating) reports. 
+            ranReportsKey = filterID + reportID
+            if ranReports[ranReportsKey] and not optRewrite:
+                print("This report was processed on %s" %(ranReports[ranReportsKey]))
+                continue
+                                            
+            if filterString:
+                reportscv = gmp.get_report(reportID, filter=filterString, report_format_id=reportFormatID, ignore_pagination=optPagination, details=optDetails)
+            else:
+                reportscv = gmp.get_report(reportID, filter_id=filterID, report_format_id=reportFormatID, ignore_pagination=optPagination, details=optDetails)
+
             obj = untangle.parse(reportscv)
             resultID = obj.get_reports_response.report['id']
             base64CVSData = obj.get_reports_response.report.cdata
             data = str(base64.b64decode(base64CVSData),"utf-8")
-            #print(data)
 
             #Write the result to file
-            #Check if we have already process the result if the  skip
-            if haveThisBeanDone(resultID):
-                writeResultToFile(resultID,data)
-            
+            writeResultToFile(resultID, data, filterID, filterString)
+#end exportReports            
 
-       #for reports in reportrow.iter('report'):
-            #    print(ET.tostring(reports,method='text', encoding='utf8').decode('utf8'))
-
-        
-def writeResultToFile(name,data):
+def writeResultToFile(name, data, fpsuffix, filterString):
     '''
     This will write the data into a file
     '''
-
-    csvFilePath = "{0}/{1}.csv".format(config['DEFAULT']['datafolder'],name)
-    jsonFilePath = "{0}/{1}.json".format(config['DEFAULT']['datafolder'],name)
-
+    
+    if fpsuffix:
+        reportPath = "{0}/{1}".format(config['DEFAULT']['datafolder'],fpsuffix)
+        csvFilePath = "{0}/{1}.csv".format(reportPath, name)
+        jsonFilePath = "{0}/{1}.json".format(reportPath,name)
+        #create the directory if it doesn't exist
+        if not path.isdir(reportPath):
+            os.makedirs(reportPath)
+            print("Created directory for filter ", fpsuffix)
+        if filterString:
+            filterStringFile = "{0}/{1}/{2}".format(config['DEFAULT']['datafolder'],fpsuffix,'filter_string.txt')
+            fs = open(filterStringFile, "w")
+            fs.write(filterString + '\n')
+            fs.close()
+    else:
+        csvFilePath = "{0}/{1}.csv".format(config['DEFAULT']['datafolder'],name)
+        jsonFilePath = "{0}/{1}.json".format(config['DEFAULT']['datafolder'],name)
+    #end if fpsuffix
+        
+    print ('Writing CVS file: ', csvFilePath)
     f = open(csvFilePath, "w")
     f.write(data)
     f.close()
-
-
-
+    
     #read the csv and add the data to a dictionary
-
+    print ('Writing JSON file: ', jsonFilePath)
     jsonFile = open(jsonFilePath, "w")
+
     with open (csvFilePath) as csvFile:
         csvReader = csv.DictReader(csvFile)
         for csvRow in csvReader:
             jsonFile.write(json.dumps(csvRow)+"\n")
+    #end with
+
+    #write the reportID, filterID, and current date time to ranreports file
+    ranReportsFile = open(config['DEFAULT']['reportfile'],'a')
+    ranReportsFile.write('%s, %s, %s\n' % (fpsuffix, name, current_datetime))
+    
+    ranReportsFile.close()
     jsonFile.close()
     csvFile.close()
-
-def haveThisBeanDone(id):
+#end writeResultToFile
+    
+def hasThisBeenDone(id, dataPath):
     '''
-    Check if a report has already bean proccess
+    Check if a report has already been proccessed
     '''
-    if path.exists("{0}/{1}.json".format(config['DEFAULT']['datafolder'],id)):
-        print("We have already processed file")
+    if path.exists(dataPath):
+        print('We have already processed this report.')
         return False
     else:
         return True
+#end hasThisBeenDone
+    
+def main(argv):
+    filterID = ''
+    filterString = ''
+    pagination = True
+    details = True
+    rewriteReports = False
+    
+    try:
+        opts, args = getopt.getopt(argv, "hpdf:s:o")
+    except getopt.GetoptError:
+        print('getReport.py -f <filter id>')
+        print('             -d disable details')
+        print('             -p enable pagination')
+        print('             -s custom filter string')
+        print('             -o over write previously processed reports')
+        pretty_print(getopt.GetoptError)
+        sys.exit(2)
+    #end except
 
-try:
-    exportReports()
-except:
-    print("Getting data failt will try again")
+    for opt, arg in opts:
+        if opt == '-h':
+            print('getReport.py -f <filter id>')
+            print('             -d disable details')
+            print('             -p enable pagination')
+            print('             -s custom filter string')
+            print('             -o over write previously processed reports')
+            sys.exit()
+        elif opt == '-f':
+            filterID = arg
+        elif opt == '-p':
+            pagination = False
+        elif opt == '-d':
+            details = False
+        elif opt =='-s':
+            filterString = arg;
+        elif opt =='-o':
+            rewriteReports = True
+    #end for
+
+    if filterID and filterString:
+        print ('-f and -s are mutually exclusive. Please use one or the other.')
+        sys.exit();
+
+    if details:
+        print('Details enabled')
+    else:
+        print('Details disabled')
+
+    if pagination:
+        print('Ignore pagination enabled')
+    else:
+        print('Ignore pagaination disabled')
+
+    if filterID:
+        print('Running reports with filter: ', filterID)
+    else:
+        print ('Running reports with no filter id')
+
+    if filterString:
+        print('Running custom report with filter: ', filterString)
+
+    exportReports(filterID, filterString, pagination, details, rewriteReports)
+#end main
+    
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/code/getReport.py
+++ b/code/getReport.py
@@ -6,9 +6,12 @@ import xml.etree.ElementTree as ET
 import untangle
 import base64
 import csv, json
-import os.path
+import os
 from os import path
+from os import makedirs
 import configparser
+import sys
+import getopt
 
 # Read the configfile
 config = configparser.ConfigParser()
@@ -16,22 +19,19 @@ config.sections()
 config.read('config/config.ini')
 
 
-
-connection = TLSConnection(hostname=config['DEFAULT']['host'])
-
-
-
-def exportReports():
+def exportReports(filterID, optPagination, optDetails):
     '''
-     This will add a target to the list and start the sca of the targets
+     This will add a target to the list and start the scan of the targets
     '''
 
-
+    connection = TLSConnection(hostname=config['DEFAULT']['host'],timeout=300)
+    print('Starting report processing')
+    
     with Gmp(connection) as gmp:
         # Login
         gmp.authenticate(config['DEFAULT']['username'], config['DEFAULT']['password'])
+        print('Connected to:', config['DEFAULT']['host'])
         
-
         #Get the CSV report type
         reportFormatID=""
         report_format = gmp.get_report_formats()
@@ -41,10 +41,9 @@ def exportReports():
             for report_format in report:
                 if report_format.text == 'CSV result list.':
                     reportFormatID= report.attrib.get('id')
-                    #reportFromatData = gmp.get_report_format(reportFormatID)
-                    #pretty_print(reportFromatData)
 
         getReports=[]
+        print ('Getting reports')
         allreports = gmp.get_reports()
         allreports_root = ET.fromstring(allreports)
         for report in allreports_root:
@@ -58,60 +57,95 @@ def exportReports():
 
         #Get out the reports and get them as csv files to use
         for reportID in getReports:
-            print("################{0}".format(reportID))
-            reportscv = gmp.get_report(reportID,report_format_id=reportFormatID,filter="apply_overrides=0 min_qod=70",ignore_pagination=True,details=True)
-            #pretty_print(reportscv)
+            print("Report ID: {0}".format(reportID))
+            reportscv = gmp.get_report(reportID, filter_id=filterID, report_format_id=reportFormatID, ignore_pagination=optPagination, details=optDetails)
             obj = untangle.parse(reportscv)
             resultID = obj.get_reports_response.report['id']
             base64CVSData = obj.get_reports_response.report.cdata
             data = str(base64.b64decode(base64CVSData),"utf-8")
-            #print(data)
 
             #Write the result to file
-            #Check if we have already process the result if the  skip
-            if haveThisBeanDone(resultID):
-                writeResultToFile(resultID,data)
-            
+            writeResultToFile(resultID,data,filterID)
+#end exportReports            
 
-       #for reports in reportrow.iter('report'):
-            #    print(ET.tostring(reports,method='text', encoding='utf8').decode('utf8'))
-
-        
-def writeResultToFile(name,data):
+def writeResultToFile(name,data,fpsuffix):
     '''
     This will write the data into a file
     '''
-
-    csvFilePath = "{0}/{1}.csv".format(config['DEFAULT']['datafolder'],name)
-    jsonFilePath = "{0}/{1}.json".format(config['DEFAULT']['datafolder'],name)
-
+    
+    if fpsuffix:
+        reportPath = "{0}/{1}".format(config['DEFAULT']['datafolder'],fpsuffix)
+        csvFilePath = "{0}/{1}.csv".format(reportPath, name)
+        jsonFilePath = "{0}/{1}.json".format(reportPath,name)
+        #create the directory if it doesn't exist
+        if not path.isdir(reportPath):
+            os.makedirs(reportPath)
+            print("Created directory for filter ", fpsuffix)
+    else:
+        csvFilePath = "{0}/{1}.csv".format(config['DEFAULT']['datafolder'],name)
+        jsonFilePath = "{0}/{1}.json".format(config['DEFAULT']['datafolder'],name)
+        
+    if (hasThisBeenDone(name,jsonFilePath) == False):
+        return
+    
+    print ('Writing CVS file: ', csvFilePath)
     f = open(csvFilePath, "w")
     f.write(data)
     f.close()
-
-
-
+    
     #read the csv and add the data to a dictionary
-
+    print ('Writing JSON file: ', jsonFilePath)
     jsonFile = open(jsonFilePath, "w")
     with open (csvFilePath) as csvFile:
         csvReader = csv.DictReader(csvFile)
         for csvRow in csvReader:
             jsonFile.write(json.dumps(csvRow)+"\n")
+    #end with
+
     jsonFile.close()
     csvFile.close()
-
-def haveThisBeanDone(id):
+#end writeResultToFile
+    
+def hasThisBeenDone(id, dataPath):
     '''
-    Check if a report has already bean proccess
+    Check if a report has already been proccessed
     '''
-    if path.exists("{0}/{1}.json".format(config['DEFAULT']['datafolder'],id)):
-        print("We have already processed file")
+    if path.exists(dataPath):
+        print('We have already processed this report')
         return False
     else:
         return True
-
-try:
-    exportReports()
-except:
-    print("Getting data failt will try again")
+#end hasThisBeenDone
+    
+def main(argv):
+    filterId = ''
+    pagination = True
+    details = True
+    try:
+        opts, args = getopt.getopt(argv, "hpdf:")
+    except getopt.GetoptError:
+        print('getReport.py -f <filter id>')
+        print('             -d disable details')
+        print('             -p enable pagination')
+        pretty_print(getopt.GetoptError)
+        sys.exit(2)
+    #end excpet
+    for opt, arg in opts:
+        if opt == '-h':
+            print('getReport.py -f <filter id>')
+            print('             -d disable details')
+            print('             -p enable pagination')
+            sys.exit()
+        elif opt == '-f':
+            filterID = arg
+        elif opt == '-p':
+            pagination = False
+        elif opt == '-d':
+            details = False
+    #end for
+    print('Running reports with filter: ', filterID)
+    exportReports(filterID, pagination, details)
+#end main
+    
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/code/getReport.py
+++ b/code/getReport.py
@@ -44,8 +44,9 @@ All values are in ASCII.
 def readRanReportsFile(taskName):
     ranReports = {}
     basepath = ''
+
     if taskName:
-        basepath = "{0}-{1}". format(config['DEFAULT']['basepath'], taskName)
+        basepath = "{0}/{1}-{2}". format(config['DEFAULT']['basepath'], "data", taskName)
     else:
         basepath = config['DEFAULT']['basepath']
 

--- a/code/getReport.py
+++ b/code/getReport.py
@@ -105,7 +105,7 @@ def exportReports(filterID, filterString, optPagination, optDetails, optRewrite)
             # we use the filterID and the rpeortID to create a key for the ranReports dict. If it exists then skip
             # that report unless we are over writing (or regenerating) reports. 
             ranReportsKey = filterID + reportID
-            if ranReports[ranReportsKey] and not optRewrite:
+            if ranReportsKey in ranReports and not optRewrite:
                 print("This report was processed on %s" %(ranReports[ranReportsKey]))
                 continue
                                             

--- a/code/run_ibex.pl
+++ b/code/run_ibex.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+# ARGV[0] is the input file
+# format is
+# config: [name of config to use]
+# raw: [raw filter id]
+# client: [client filter id]
+
+# read in the config file and then build commands to 
+# run Ibex/getReport.py
+
+my $target = $ARGV[0];
+my $rawcmd = "";
+my $clientcmd = "";
+my $ibexpath = "/opt/openvas-exporter/code/getReport.py";
+my $config = "/opt/openvas-exporter/code/config/ibex.config";
+
+if (! -e $ibexpath) {
+    print "getReport.py not found at $ibexpath\n";
+    exit;
+}
+
+if (! -e $config) {
+    print "ibex config not found at $config\n";
+    exit;
+}
+
+sub  trim { 
+    my $s = shift; 
+    $s =~ s/^\s+|\s+$//g; 
+    return $s 
+};
+
+
+$target = trim($target);
+
+if (! $target) {
+    print "You must provide a taskname.\n";
+    exit;
+}
+
+open (FH, "<", $config) or die ("Cannot open $file");
+while (<FH>) {
+    chomp $_;
+    (my $key, my $value) = split ":", $_;
+    $parameter{$key} = trim($value);
+} 
+
+if (!$parameter{config}) {
+    print "Config file not set in run file\n";
+    exit;
+}
+
+if ($parameter{'raw'}) {
+    $rawcmd = "python3 $ibexpath -f $parameter{raw} -t $target -i $parameter{config}";
+}
+
+if ($parameter{'client'}) {
+    $clientcmd = "python3 $ibexpath -f $parameter{client} -t $target -i $parameter{config} -P";
+}
+
+print "About to run the following commands\n";
+print "Client: $clientcmd\n";
+print "Raw: $rawcmd\n";
+
+print "Starting client filter processing\n";
+system ($clientcmd);
+
+print "Starting raw filter processing\n";
+system ($rawcmd);
+
+print "Completed\n";


### PR DESCRIPTION
@mattiashem 
Mattias,

We're looking at using openvas-exporter in our environment as vulnwhisperer was a bit too constrained in how it handled filtering. I've made some changes I thought I would share
1) You can now enter a filterid on the command line with -f
2) You can enter a custom filter string on the command line with -s
3) You can enable and disable both pagination and details with -p and -d respectively
4) Made some changes to the workflow and fixed some typos

Any reports generated with a filter id are stored in datafold/<filter_id>.
Reports generated with a custom filter string are stored in a subfolder named with the sha1 hash of the string. The filter string itself is saved in a file called 'filter_string.txt' for reference. 

Thanks for giving me a good base to work from. 